### PR TITLE
Multiprotocol functions

### DIFF
--- a/src/mqtt_pal.c
+++ b/src/mqtt_pal.c
@@ -35,7 +35,7 @@ SOFTWARE.
 #ifdef MQTT_USE_MBEDTLS
 #include <mbedtls/ssl.h>
 
-ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
+ssize_t mqtt_pal_mbedtls_sendall(mqtt_pal_mbedtls_socket_handle fd, const void* buf, size_t len, int flags) {
     size_t sent = 0;
     while(sent < len) {
         int rv = mbedtls_ssl_write(fd, buf + sent, len - sent);
@@ -59,7 +59,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     return sent;
 }
 
-ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
+ssize_t mqtt_pal_mbedtls_recvall(mqtt_pal_mbedtls_socket_handle fd, void* buf, size_t bufsz, int flags) {
     const void *const start = buf;
     int rv;
     do {
@@ -99,10 +99,12 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
     return buf - start;
 }
 
-#elif defined(MQTT_USE_WOLFSSL)
+#endif
+
+#if defined(MQTT_USE_WOLFSSL)
 #include <wolfssl/ssl.h>
 
-ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
+ssize_t mqtt_pal_wolfssl_sendall(mqtt_pal_wolfssl_socket_handle fd, const void* buf, size_t len, int flags) {
     size_t sent = 0;
     while (sent < len) {
         int tmp = wolfSSL_write(fd, buf + sent, (int)(len - sent));
@@ -118,7 +120,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     return (ssize_t)sent;
 }
 
-ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
+ssize_t mqtt_pal_wolfssl_recvall(mqtt_pal_wolfssl_socket_handle fd, void* buf, size_t bufsz, int flags) {
     const void* const start = buf;
     int tmp;
     do {
@@ -137,7 +139,9 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
     return (ssize_t)(buf - start);
 }
 
-#elif defined(MQTT_USE_BEARSSL)
+#endif
+
+#if defined(MQTT_USE_BEARSSL)
 #include <bearssl.h>
 #include <memory.h>
 
@@ -182,7 +186,7 @@ static int do_rec_data(mqtt_pal_socket_handle fd, unsigned int status) {
     return MQTT_OK;
 }
 
-ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
+ssize_t mqtt_pal_bearssl_sendall(mqtt_pal_bearssl_socket_handle fd, const void* buf, size_t len, int flags) {
     int rc = MQTT_OK;
     uint8_t *buffer;
     size_t length;
@@ -228,7 +232,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     return len;
 }
 
-ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
+ssize_t mqtt_pal_bearssl_recvall(mqtt_pal_bearssl_socket_handle fd, void* buf, size_t bufsz, int flags) {
     int rc = MQTT_OK;
     uint8_t *buffer;
     size_t length;
@@ -266,12 +270,14 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
     return bufsz - remaining_bytes;
 }
 
-#elif defined(MQTT_USE_BIO)
+#endif
+
+#if defined(MQTT_USE_BIO)
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
-ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
+ssize_t mqtt_pal_bio_sendall(mqtt_pal_bio_socket_handle fd, const void* buf, size_t len, int flags) {
     size_t sent = 0;
     while(sent < len) {
         int tmp = BIO_write(fd, (const char*)buf + sent, len - sent);
@@ -285,7 +291,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     return sent;
 }
 
-ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
+ssize_t mqtt_pal_bio_recvall(mqtt_pal_bio_socket_handle fd, void* buf, size_t bufsz, int flags) {
     const char* const start = buf;
     char* bufptr = buf;
     int rv;
@@ -304,11 +310,15 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
     return (ssize_t)(bufptr - start);
 }
 
-#elif defined(__unix__) || defined(__APPLE__) || defined(__NuttX__)
+#endif
+
+#if defined(MQTT_USE_TCP)
+
+#if defined(__unix__) || defined(__APPLE__) || defined(__NuttX__)
 
 #include <errno.h>
 
-ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
+ssize_t mqtt_pal_tcp_sendall(mqtt_pal_tcp_socket_handle fd, const void* buf, size_t len, int flags) {
     size_t sent = 0;
     while(sent < len) {
         ssize_t tmp = send(fd, buf + sent, len - sent, flags);
@@ -323,7 +333,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     return sent;
 }
 
-ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
+ssize_t mqtt_pal_tcp_recvall(mqtt_pal_tcp_socket_handle fd, void* buf, size_t bufsz, int flags) {
     const void *const start = buf;
     ssize_t rv;
     do {
@@ -345,7 +355,7 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
 
 #include <errno.h>
 
-ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
+ssize_t mqtt_pal_tcp_sendall(mqtt_pal_tcp_socket_handle fd, const void* buf, size_t len, int flags) {
     size_t sent = 0;
     while(sent < len) {
         ssize_t tmp = send(fd, (char*)buf + sent, len - sent, flags);
@@ -357,7 +367,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     return sent;
 }
 
-ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
+ssize_t mqtt_pal_tcp_recvall(mqtt_pal_tcp_socket_handle fd, void* buf, size_t bufsz, int flags) {
     const char *const start = buf;
     ssize_t rv;
     do {
@@ -380,7 +390,9 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
 
 #else
 
-#error No PAL!
+#error No TCP PAL!
+
+#endif
 
 #endif
 


### PR DESCRIPTION
Create explicit functions for each PAL protocol

Functions for each protocol are created, so that they can be used even when `MQTT_USE_CUSTOM_SOCKET_HANDLE` is defined.

The functions and types are mapped to default names in case `MQTT_USE_CUSTOM_SOCKET_HANDLE` is not used, so maintaining the default functionality.
